### PR TITLE
Optimize hero image loading and asset caching

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -4,6 +4,8 @@
   ExpiresByType image/png "access plus 1 year"
   ExpiresByType image/jpeg "access plus 1 year"
   ExpiresByType image/gif "access plus 1 year"
+  ExpiresByType image/svg+xml "access plus 1 year"
+  ExpiresByType image/x-icon "access plus 1 year"
   ExpiresByType text/css "access plus 1 year"
   ExpiresByType application/javascript "access plus 1 year"
   ExpiresByType text/javascript "access plus 1 year"
@@ -11,7 +13,11 @@
 </IfModule>
 
 <IfModule mod_headers.c>
-  <FilesMatch "\.(css|js|png|jpe?g|gif|webp|woff2?)$">
+  <FilesMatch "\.(css|js|png|jpe?g|gif|webp|svg|ico|woff2?)$">
     Header set Cache-Control "public, max-age=31536000, immutable"
   </FilesMatch>
+</IfModule>
+
+<IfModule mod_deflate.c>
+  AddOutputFilterByType DEFLATE text/html text/plain text/xml text/css application/javascript application/json
 </IfModule>

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link rel="preload" as="image" href="/wp-content/uploads/2025/08/Untitled-2-2.webp" imagesrcset="/wp-content/uploads/2025/08/Untitled-2-2.webp 486w, /wp-content/uploads/2025/08/Untitled-2-2-243x300.webp 243w" imagesizes="(max-width: 486px) 100vw, 486px">
+        <link rel="preload" as="image" href="/wp-content/uploads/2025/08/Slice-1-scaled.webp" imagesrcset="/wp-content/uploads/2025/08/Slice-1-scaled.webp 1920w, /wp-content/uploads/2025/08/Slice-1-1536x685.webp 1536w, /wp-content/uploads/2025/08/Slice-1-1024x457.webp 1024w, /wp-content/uploads/2025/08/Slice-1-768x342.webp 768w, /wp-content/uploads/2025/08/Slice-1-300x134.webp 300w" imagesizes="(max-width: 1920px) 100vw, 1920px">
 <link rel="alternate" type="application/rss+xml" title="DigitalCraft &raquo; Feed" href="/feed/">
 <link rel="alternate" type="application/rss+xml" title="DigitalCraft &raquo; Comments Feed" href="/comments/feed/">
 <!-- SureRank Meta Data -->
@@ -579,7 +580,7 @@ flexibility(document.documentElement);
 		<div class="elementor-element elementor-element-4f0a32f e-con-full e-flex e-con e-child" data-id="4f0a32f" data-element_type="container">
 				<div class="elementor-element elementor-element-f11a440 elementor-widget elementor-widget-image" data-id="f11a440" data-element_type="widget" data-widget_type="image.default">
 				<div class="elementor-widget-container">
-															<img loading="lazy" decoding="async" width="1920" height="857" src="/wp-content/uploads/2025/08/Slice-1-scaled.webp" class="attachment-full size-full wp-image-1527" alt="slice 1" srcset="/wp-content/uploads/2025/08/Slice-1-scaled.webp 1920w, /wp-content/uploads/2025/08/Slice-1-300x134.webp 300w, /wp-content/uploads/2025/08/Slice-1-1024x457.webp 1024w, /wp-content/uploads/2025/08/Slice-1-768x342.webp 768w, /wp-content/uploads/2025/08/Slice-1-1536x685.webp 1536w" sizes="(max-width: 1920px) 100vw, 1920px">															</div>
+															<img fetchpriority="high" loading="eager" decoding="async" width="1920" height="857" src="/wp-content/uploads/2025/08/Slice-1-scaled.webp" class="attachment-full size-full wp-image-1527" alt="slice 1" srcset="/wp-content/uploads/2025/08/Slice-1-scaled.webp 1920w, /wp-content/uploads/2025/08/Slice-1-300x134.webp 300w, /wp-content/uploads/2025/08/Slice-1-1024x457.webp 1024w, /wp-content/uploads/2025/08/Slice-1-768x342.webp 768w, /wp-content/uploads/2025/08/Slice-1-1536x685.webp 1536w" sizes="(max-width: 1920px) 100vw, 1920px">															</div>
 				</div>
 				</div>
 		<div class="elementor-element elementor-element-d0cabc2 e-con-full e-flex e-con e-child" data-id="d0cabc2" data-element_type="container">


### PR DESCRIPTION
## Summary
- Preload and eagerly load hero image to reduce largest contentful paint delays
- Extend cache headers and enable gzip compression for static assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acccc278748322a0bfd80eeeb9eebb