### PR TITLE
Add FAQ toggle behavior for static site

### DIFF
--- a/assets/js/faq.js
+++ b/assets/js/faq.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', function () {
+  document.querySelectorAll('.elementor-toggle .elementor-tab-title').forEach(function (title) {
+    var contentId = title.getAttribute('aria-controls');
+    var content = document.getElementById(contentId);
+    if (content && title.getAttribute('aria-expanded') !== 'true') {
+      content.style.display = 'none';
+    }
+    title.addEventListener('click', function (e) {
+      e.preventDefault();
+      var expanded = title.getAttribute('aria-expanded') === 'true';
+      title.setAttribute('aria-expanded', String(!expanded));
+      if (content) {
+        content.style.display = expanded ? 'none' : 'block';
+      }
+    });
+  });
+});

--- a/index.html
+++ b/index.html
@@ -102,6 +102,7 @@ flexibility(document.documentElement);
 <script src="/wp-includes/js/jquery/jquery.min.js?ver=3.7.1" id="jquery-core-js"></script>
 <script src="/wp-includes/js/jquery/jquery-migrate.min.js?ver=3.4.1" id="jquery-migrate-js"></script>
 <script src="/assets/js/behavior.js" defer></script>
+<script src="/assets/js/faq.js" defer></script>
 <link rel="https://api.w.org/" href="/wp-json/"><link rel="alternate" title="JSON" type="application/json" href="/wp-json/wp/v2/pages/49"><link rel="EditURI" type="application/rsd+xml" title="RSD" href="/xmlrpc.php?rsd">
 <meta name="generator" content="WordPress 6.8.2">
 <link rel="shortlink" href="/">


### PR DESCRIPTION
## Summary
- ensure FAQ entries can toggle open/closed without Elementor
- load custom FAQ script on the site

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad024795988322959e032b8f35bc2c