### PR TITLE
Refactor Elementor asset paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,30 +69,30 @@ window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/16
 :root :where(.wp-block-pullquote){font-size: 1.5em;line-height: 1.6;}
 </style>
 <link rel="stylesheet" id="hfe-style-css" href="/wp-content/plugins/header-footer-elementor/assets/css/header-footer-elementor.css?ver=2.4.9" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="elementor-icons-css" href="/wp-content/plugins/elementor/assets/lib/eicons/css/elementor-icons.min.css?ver=5.43.0" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="elementor-frontend-css" href="/wp-content/plugins/elementor/assets/css/frontend.min.css?ver=3.31.2" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="elementor-icons-css" href="/assets/lib/eicons/css/elementor-icons.min.css?ver=5.43.0" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="elementor-frontend-css" href="/assets/css/frontend.min.css?ver=3.31.2" media="print" onload="this.media='all'">
 <link rel="stylesheet" id="elementor-post-1439-css" href="/wp-content/uploads/elementor/css/post-1439.css?ver=1756072020" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="widget-image-css" href="/wp-content/plugins/elementor/assets/css/widget-image.min.css?ver=3.31.2" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="widget-heading-css" href="/wp-content/plugins/elementor/assets/css/widget-heading.min.css?ver=3.31.2" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="widget-icon-box-css" href="/wp-content/plugins/elementor/assets/css/widget-icon-box.min.css?ver=3.31.2" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="widget-icon-list-css" href="/wp-content/plugins/elementor/assets/css/widget-icon-list.min.css?ver=3.31.2" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="widget-social-icons-css" href="/wp-content/plugins/elementor/assets/css/widget-social-icons.min.css?ver=3.31.2" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="e-apple-webkit-css" href="/wp-content/plugins/elementor/assets/css/conditionals/apple-webkit.min.css?ver=3.31.2" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="widget-toggle-css" href="/wp-content/plugins/elementor/assets/css/widget-toggle.min.css?ver=3.31.2" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="widget-image-css" href="/assets/css/widget-image.min.css?ver=3.31.2" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="widget-heading-css" href="/assets/css/widget-heading.min.css?ver=3.31.2" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="widget-icon-box-css" href="/assets/css/widget-icon-box.min.css?ver=3.31.2" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="widget-icon-list-css" href="/assets/css/widget-icon-list.min.css?ver=3.31.2" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="widget-social-icons-css" href="/assets/css/widget-social-icons.min.css?ver=3.31.2" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="e-apple-webkit-css" href="/assets/css/conditionals/apple-webkit.min.css?ver=3.31.2" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="widget-toggle-css" href="/assets/css/widget-toggle.min.css?ver=3.31.2" media="print" onload="this.media='all'">
 <link rel="stylesheet" id="elementor-post-49-css" href="/wp-content/uploads/elementor/css/post-49.css?ver=1756072020" media="print" onload="this.media='all'">
 <link rel="stylesheet" id="uag-style-49-css" href="/wp-content/uploads/uag-plugin/assets/0/uag-css-49.css?ver=1756065228" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="hfe-elementor-icons-css" href="/wp-content/plugins/elementor/assets/lib/eicons/css/elementor-icons.min.css?ver=5.34.0" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="hfe-icons-list-css" href="/wp-content/plugins/elementor/assets/css/widget-icon-list.min.css?ver=3.24.3" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="hfe-social-icons-css" href="/wp-content/plugins/elementor/assets/css/widget-social-icons.min.css?ver=3.24.0" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="hfe-social-share-icons-brands-css" href="/wp-content/plugins/elementor/assets/lib/font-awesome/css/brands.css?ver=5.15.3" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="hfe-social-share-icons-fontawesome-css" href="/wp-content/plugins/elementor/assets/lib/font-awesome/css/fontawesome.css?ver=5.15.3" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="hfe-nav-menu-icons-css" href="/wp-content/plugins/elementor/assets/lib/font-awesome/css/solid.css?ver=5.15.3" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="hfe-elementor-icons-css" href="/assets/lib/eicons/css/elementor-icons.min.css?ver=5.34.0" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="hfe-icons-list-css" href="/assets/css/widget-icon-list.min.css?ver=3.24.3" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="hfe-social-icons-css" href="/assets/css/widget-social-icons.min.css?ver=3.24.0" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="hfe-social-share-icons-brands-css" href="/assets/lib/font-awesome/css/brands.css?ver=5.15.3" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="hfe-social-share-icons-fontawesome-css" href="/assets/lib/font-awesome/css/fontawesome.css?ver=5.15.3" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="hfe-nav-menu-icons-css" href="/assets/lib/font-awesome/css/solid.css?ver=5.15.3" media="print" onload="this.media='all'">
 <!--link rel="stylesheet" id="elementor-gf-local-roboto-css" href="/wp-content/uploads/elementor/google-fonts/css/roboto.css?ver=1755546534" media="all"-->
 <!--link rel="stylesheet" id="elementor-gf-local-robotoslab-css" href="/wp-content/uploads/elementor/google-fonts/css/robotoslab.css?ver=1755546652" media="all"-->
-<link rel="stylesheet" id="elementor-icons-shared-0-css" href="/wp-content/plugins/elementor/assets/lib/font-awesome/css/fontawesome.min.css?ver=5.15.3" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="elementor-icons-fa-regular-css" href="/wp-content/plugins/elementor/assets/lib/font-awesome/css/regular.min.css?ver=5.15.3" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="elementor-icons-fa-solid-css" href="/wp-content/plugins/elementor/assets/lib/font-awesome/css/solid.min.css?ver=5.15.3" media="print" onload="this.media='all'">
-<link rel="stylesheet" id="elementor-icons-fa-brands-css" href="/wp-content/plugins/elementor/assets/lib/font-awesome/css/brands.min.css?ver=5.15.3" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="elementor-icons-shared-0-css" href="/assets/lib/font-awesome/css/fontawesome.min.css?ver=5.15.3" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="elementor-icons-fa-regular-css" href="/assets/lib/font-awesome/css/regular.min.css?ver=5.15.3" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="elementor-icons-fa-solid-css" href="/assets/lib/font-awesome/css/solid.min.css?ver=5.15.3" media="print" onload="this.media='all'">
+<link rel="stylesheet" id="elementor-icons-fa-brands-css" href="/assets/lib/font-awesome/css/brands.min.css?ver=5.15.3" media="print" onload="this.media='all'">
 <!--[if IE]>
 <script src="/wp-content/themes/astra/assets/js/minified/flexibility.min.js?ver=4.11.9" id="astra-flexibility-js" defer></script>
 <script id="astra-flexibility-js-after">
@@ -849,13 +849,13 @@ jQuery( document ).ready( function($) {
 var starter_templates_zip_preview = {"AstColorPaletteVarPrefix":"--ast-global-color-","AstEleColorPaletteVarPrefix":["ast-global-color-0","ast-global-color-1","ast-global-color-2","ast-global-color-3","ast-global-color-4","ast-global-color-5","ast-global-color-6","ast-global-color-7","ast-global-color-8"]};
 </script>
 <script src="/wp-content/plugins/astra-sites/inc/lib/onboarding/assets/dist/template-preview/main.js?ver=06758d4d807d9d22c6ea" id="starter-templates-zip-preview-js"></script>
-<script src="/wp-content/plugins/elementor/assets/js/webpack.runtime.min.js?ver=3.31.2" id="elementor-webpack-runtime-js"></script>
-<script src="/wp-content/plugins/elementor/assets/js/frontend-modules.min.js?ver=3.31.2" id="elementor-frontend-modules-js"></script>
+<script src="/assets/js/webpack.runtime.min.js?ver=3.31.2" id="elementor-webpack-runtime-js"></script>
+<script src="/assets/js/frontend-modules.min.js?ver=3.31.2" id="elementor-frontend-modules-js"></script>
 <script src="/wp-includes/js/jquery/ui/core.min.js?ver=1.13.3" id="jquery-ui-core-js"></script>
 <script id="elementor-frontend-js-before">
 var elementorFrontendConfig = {"environmentMode":{"edit":false,"wpPreview":false,"isScriptDebug":false},"i18n":{"shareOnFacebook":"Share on Facebook","shareOnTwitter":"Share on Twitter","pinIt":"Pin it","download":"Download","downloadImage":"Download image","fullscreen":"Fullscreen","zoom":"Zoom","share":"Share","playVideo":"Play Video","previous":"Previous","next":"Next","close":"Close","a11yCarouselPrevSlideMessage":"Previous slide","a11yCarouselNextSlideMessage":"Next slide","a11yCarouselFirstSlideMessage":"This is the first slide","a11yCarouselLastSlideMessage":"This is the last slide","a11yCarouselPaginationBulletMessage":"Go to slide"},"is_rtl":false,"breakpoints":{"xs":0,"sm":480,"md":768,"lg":1025,"xl":1440,"xxl":1600},"responsive":{"breakpoints":{"mobile":{"label":"Mobile Portrait","value":767,"default_value":767,"direction":"max","is_enabled":true},"mobile_extra":{"label":"Mobile Landscape","value":880,"default_value":880,"direction":"max","is_enabled":false},"tablet":{"label":"Tablet Portrait","value":1024,"default_value":1024,"direction":"max","is_enabled":true},"tablet_extra":{"label":"Tablet Landscape","value":1200,"default_value":1200,"direction":"max","is_enabled":false},"laptop":{"label":"Laptop","value":1366,"default_value":1366,"direction":"max","is_enabled":false},"widescreen":{"label":"Widescreen","value":2400,"default_value":2400,"direction":"min","is_enabled":false}},"hasCustomBreakpoints":false},"version":"3.31.2","is_static":false,"experimentalFeatures":{"additional_custom_breakpoints":true,"container":true,"nested-elements":true,"e_element_cache":true,"home_screen":true,"global_classes_should_enforce_capabilities":true,"e_variables":true,"cloud-library":true,"e_opt_in_v4_page":true},"urls":{"assets":"\\/wp-content\/plugins\/elementor\/assets\/","ajaxurl":"\\/wp-admin\/admin-ajax.php","uploadUrl":"\\/wp-content\/uploads"},"nonces":{"floatingButtonsClickTracking":"9df48e2183"},"swiperClass":"swiper","settings":{"page":[],"editorPreferences":[]},"kit":{"active_breakpoints":["viewport_mobile","viewport_tablet"],"global_image_lightbox":"yes","lightbox_enable_counter":"yes","lightbox_enable_fullscreen":"yes","lightbox_enable_zoom":"yes","lightbox_enable_share":"yes","lightbox_title_src":"title","lightbox_description_src":"description"},"post":{"id":49,"title":"Home%20-%20DigitalCraft","excerpt":"","featuredImage":false}};
 </script>
-<script src="/wp-content/plugins/elementor/assets/js/frontend.min.js?ver=3.31.2" id="elementor-frontend-js"></script>
+<script src="/assets/js/frontend.min.js?ver=3.31.2" id="elementor-frontend-js"></script>
 			<script>
 			/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())},!1);
 			</script>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -62,17 +62,17 @@ window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/16
 :root :where(.wp-block-pullquote){font-size: 1.5em;line-height: 1.6;}
 </style>
 <link rel="stylesheet" id="hfe-style-css" href="./wp-content/plugins/header-footer-elementor/assets/css/header-footer-elementor.css?ver=2.4.9" media="all">
-<link rel="stylesheet" id="elementor-icons-css" href="./wp-content/plugins/elementor/assets/lib/eicons/css/elementor-icons.min.css?ver=5.43.0" media="all">
-<link rel="stylesheet" id="elementor-frontend-css" href="./wp-content/plugins/elementor/assets/css/frontend.min.css?ver=3.31.2" media="all">
+<link rel="stylesheet" id="elementor-icons-css" href="/assets/lib/eicons/css/elementor-icons.min.css?ver=5.43.0" media="all">
+<link rel="stylesheet" id="elementor-frontend-css" href="/assets/css/frontend.min.css?ver=3.31.2" media="all">
 <link rel="stylesheet" id="elementor-post-1439-css" href="./wp-content/uploads/elementor/css/post-1439.css?ver=1756072020" media="all">
 <link rel="stylesheet" id="elementor-post-1544-css" href="./wp-content/uploads/elementor/css/post-1544.css?ver=1756072339" media="all">
 <link rel="stylesheet" id="uag-style-1544-css" href="./wp-content/uploads/uag-plugin/assets/2000/uag-css-1544.css?ver=1756065228" media="all">
-<link rel="stylesheet" id="hfe-elementor-icons-css" href="./wp-content/plugins/elementor/assets/lib/eicons/css/elementor-icons.min.css?ver=5.34.0" media="all">
-<link rel="stylesheet" id="hfe-icons-list-css" href="./wp-content/plugins/elementor/assets/css/widget-icon-list.min.css?ver=3.24.3" media="all">
-<link rel="stylesheet" id="hfe-social-icons-css" href="./wp-content/plugins/elementor/assets/css/widget-social-icons.min.css?ver=3.24.0" media="all">
-<link rel="stylesheet" id="hfe-social-share-icons-brands-css" href="./wp-content/plugins/elementor/assets/lib/font-awesome/css/brands.css?ver=5.15.3" media="all">
-<link rel="stylesheet" id="hfe-social-share-icons-fontawesome-css" href="./wp-content/plugins/elementor/assets/lib/font-awesome/css/fontawesome.css?ver=5.15.3" media="all">
-<link rel="stylesheet" id="hfe-nav-menu-icons-css" href="./wp-content/plugins/elementor/assets/lib/font-awesome/css/solid.css?ver=5.15.3" media="all">
+<link rel="stylesheet" id="hfe-elementor-icons-css" href="/assets/lib/eicons/css/elementor-icons.min.css?ver=5.34.0" media="all">
+<link rel="stylesheet" id="hfe-icons-list-css" href="/assets/css/widget-icon-list.min.css?ver=3.24.3" media="all">
+<link rel="stylesheet" id="hfe-social-icons-css" href="/assets/css/widget-social-icons.min.css?ver=3.24.0" media="all">
+<link rel="stylesheet" id="hfe-social-share-icons-brands-css" href="/assets/lib/font-awesome/css/brands.css?ver=5.15.3" media="all">
+<link rel="stylesheet" id="hfe-social-share-icons-fontawesome-css" href="/assets/lib/font-awesome/css/fontawesome.css?ver=5.15.3" media="all">
+<link rel="stylesheet" id="hfe-nav-menu-icons-css" href="/assets/lib/font-awesome/css/solid.css?ver=5.15.3" media="all">
 <!--link rel="stylesheet" id="elementor-gf-local-roboto-css" href="./wp-content/uploads/elementor/google-fonts/css/roboto.css?ver=1755546534" media="all"-->
 <!--link rel="stylesheet" id="elementor-gf-local-robotoslab-css" href="./wp-content/uploads/elementor/google-fonts/css/robotoslab.css?ver=1755546652" media="all"-->
 <!--[if IE]>
@@ -371,13 +371,13 @@ jQuery( document ).ready( function($) {
 var starter_templates_zip_preview = {"AstColorPaletteVarPrefix":"--ast-global-color-","AstEleColorPaletteVarPrefix":["ast-global-color-0","ast-global-color-1","ast-global-color-2","ast-global-color-3","ast-global-color-4","ast-global-color-5","ast-global-color-6","ast-global-color-7","ast-global-color-8"]};
 </script>
 <script src="./wp-content/plugins/astra-sites/inc/lib/onboarding/assets/dist/template-preview/main.js?ver=06758d4d807d9d22c6ea" id="starter-templates-zip-preview-js"></script>
-<!--script src="./wp-content/plugins/elementor/assets/js/webpack.runtime.min.js?ver=3.31.2" id="elementor-webpack-runtime-js"></script-->
-<!--script src="./wp-content/plugins/elementor/assets/js/frontend-modules.min.js?ver=3.31.2" id="elementor-frontend-modules-js"></script-->
+<!--script src="/assets/js/webpack.runtime.min.js?ver=3.31.2" id="elementor-webpack-runtime-js"></script-->
+<!--script src="/assets/js/frontend-modules.min.js?ver=3.31.2" id="elementor-frontend-modules-js"></script-->
 <script src="./wp-includes/js/jquery/ui/core.min.js?ver=1.13.3" id="jquery-ui-core-js"></script>
 <script id="elementor-frontend-js-before">
 var elementorFrontendConfig = {"environmentMode":{"edit":false,"wpPreview":false,"isScriptDebug":false},"i18n":{"shareOnFacebook":"Share on Facebook","shareOnTwitter":"Share on Twitter","pinIt":"Pin it","download":"Download","downloadImage":"Download image","fullscreen":"Fullscreen","zoom":"Zoom","share":"Share","playVideo":"Play Video","previous":"Previous","next":"Next","close":"Close","a11yCarouselPrevSlideMessage":"Previous slide","a11yCarouselNextSlideMessage":"Next slide","a11yCarouselFirstSlideMessage":"This is the first slide","a11yCarouselLastSlideMessage":"This is the last slide","a11yCarouselPaginationBulletMessage":"Go to slide"},"is_rtl":false,"breakpoints":{"xs":0,"sm":480,"md":768,"lg":1025,"xl":1440,"xxl":1600},"responsive":{"breakpoints":{"mobile":{"label":"Mobile Portrait","value":767,"default_value":767,"direction":"max","is_enabled":true},"mobile_extra":{"label":"Mobile Landscape","value":880,"default_value":880,"direction":"max","is_enabled":false},"tablet":{"label":"Tablet Portrait","value":1024,"default_value":1024,"direction":"max","is_enabled":true},"tablet_extra":{"label":"Tablet Landscape","value":1200,"default_value":1200,"direction":"max","is_enabled":false},"laptop":{"label":"Laptop","value":1366,"default_value":1366,"direction":"max","is_enabled":false},"widescreen":{"label":"Widescreen","value":2400,"default_value":2400,"direction":"min","is_enabled":false}},"hasCustomBreakpoints":false},"version":"3.31.2","is_static":false,"experimentalFeatures":{"additional_custom_breakpoints":true,"container":true,"nested-elements":true,"e_element_cache":true,"home_screen":true,"global_classes_should_enforce_capabilities":true,"e_variables":true,"cloud-library":true,"e_opt_in_v4_page":true},"urls":{"assets":"\/wp-content\/plugins\/elementor\/assets\/","ajaxurl":"\/wp-admin\/admin-ajax.php","uploadUrl":"\/wp-content\/uploads"},"nonces":{"floatingButtonsClickTracking":"9df48e2183"},"swiperClass":"swiper","settings":{"page":[],"editorPreferences":[]},"kit":{"active_breakpoints":["viewport_mobile","viewport_tablet"],"global_image_lightbox":"yes","lightbox_enable_counter":"yes","lightbox_enable_fullscreen":"yes","lightbox_enable_zoom":"yes","lightbox_enable_share":"yes","lightbox_title_src":"title","lightbox_description_src":"description"},"post":{"id":1544,"title":"Privacy%20%26%20Policy%20-%20DigitalCraft","excerpt":"","featuredImage":false}};
 </script>
-<script src="./wp-content/plugins/elementor/assets/js/frontend.min.js?ver=3.31.2" id="elementor-frontend-js"></script>
+<script src="/assets/js/frontend.min.js?ver=3.31.2" id="elementor-frontend-js"></script>
 			<script>
 			/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())},!1);
 			</script>

--- a/privacy-policy/terms/index.html
+++ b/privacy-policy/terms/index.html
@@ -62,18 +62,18 @@ window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/16
 :root :where(.wp-block-pullquote){font-size: 1.5em;line-height: 1.6;}
 </style>
 <link rel="stylesheet" id="hfe-style-css" href="/wp-content/plugins/header-footer-elementor/assets/css/header-footer-elementor.css?ver=2.4.9" media="all">
-<link rel="stylesheet" id="elementor-icons-css" href="/wp-content/plugins/elementor/assets/lib/eicons/css/elementor-icons.min.css?ver=5.43.0" media="all">
-<link rel="stylesheet" id="elementor-frontend-css" href="/wp-content/plugins/elementor/assets/css/frontend.min.css?ver=3.31.2" media="all">
+<link rel="stylesheet" id="elementor-icons-css" href="/assets/lib/eicons/css/elementor-icons.min.css?ver=5.43.0" media="all">
+<link rel="stylesheet" id="elementor-frontend-css" href="/assets/css/frontend.min.css?ver=3.31.2" media="all">
 <link rel="stylesheet" id="elementor-post-1439-css" href="/wp-content/uploads/elementor/css/post-1439.css?ver=1756072020" media="all">
-<link rel="stylesheet" id="widget-heading-css" href="/wp-content/plugins/elementor/assets/css/widget-heading.min.css?ver=3.31.2" media="all">
+<link rel="stylesheet" id="widget-heading-css" href="/assets/css/widget-heading.min.css?ver=3.31.2" media="all">
 <link rel="stylesheet" id="elementor-post-682-css" href="/wp-content/uploads/elementor/css/post-682.css?ver=1756072572" media="all">
 <link rel="stylesheet" id="uag-style-682-css" href="/wp-content/uploads/uag-plugin/assets/1000/uag-css-682.css?ver=1756065228" media="all">
-<link rel="stylesheet" id="hfe-elementor-icons-css" href="/wp-content/plugins/elementor/assets/lib/eicons/css/elementor-icons.min.css?ver=5.34.0" media="all">
-<link rel="stylesheet" id="hfe-icons-list-css" href="/wp-content/plugins/elementor/assets/css/widget-icon-list.min.css?ver=3.24.3" media="all">
-<link rel="stylesheet" id="hfe-social-icons-css" href="/wp-content/plugins/elementor/assets/css/widget-social-icons.min.css?ver=3.24.0" media="all">
-<link rel="stylesheet" id="hfe-social-share-icons-brands-css" href="/wp-content/plugins/elementor/assets/lib/font-awesome/css/brands.css?ver=5.15.3" media="all">
-<link rel="stylesheet" id="hfe-social-share-icons-fontawesome-css" href="/wp-content/plugins/elementor/assets/lib/font-awesome/css/fontawesome.css?ver=5.15.3" media="all">
-<link rel="stylesheet" id="hfe-nav-menu-icons-css" href="/wp-content/plugins/elementor/assets/lib/font-awesome/css/solid.css?ver=5.15.3" media="all">
+<link rel="stylesheet" id="hfe-elementor-icons-css" href="/assets/lib/eicons/css/elementor-icons.min.css?ver=5.34.0" media="all">
+<link rel="stylesheet" id="hfe-icons-list-css" href="/assets/css/widget-icon-list.min.css?ver=3.24.3" media="all">
+<link rel="stylesheet" id="hfe-social-icons-css" href="/assets/css/widget-social-icons.min.css?ver=3.24.0" media="all">
+<link rel="stylesheet" id="hfe-social-share-icons-brands-css" href="/assets/lib/font-awesome/css/brands.css?ver=5.15.3" media="all">
+<link rel="stylesheet" id="hfe-social-share-icons-fontawesome-css" href="/assets/lib/font-awesome/css/fontawesome.css?ver=5.15.3" media="all">
+<link rel="stylesheet" id="hfe-nav-menu-icons-css" href="/assets/lib/font-awesome/css/solid.css?ver=5.15.3" media="all">
 <link rel="stylesheet" id="elementor-gf-local-roboto-css" href="/wp-content/uploads/elementor/google-fonts/css/roboto.css?ver=1755546534" media="all">
 <link rel="stylesheet" id="elementor-gf-local-robotoslab-css" href="/wp-content/uploads/elementor/google-fonts/css/robotoslab.css?ver=1755546652" media="all">
 <!--[if IE]>
@@ -340,13 +340,13 @@ jQuery( document ).ready( function($) {
 var starter_templates_zip_preview = {"AstColorPaletteVarPrefix":"--ast-global-color-","AstEleColorPaletteVarPrefix":["ast-global-color-0","ast-global-color-1","ast-global-color-2","ast-global-color-3","ast-global-color-4","ast-global-color-5","ast-global-color-6","ast-global-color-7","ast-global-color-8"]};
 </script>
 <script src="/wp-content/plugins/astra-sites/inc/lib/onboarding/assets/dist/template-preview/main.js?ver=06758d4d807d9d22c6ea" id="starter-templates-zip-preview-js"></script>
-<script src="/wp-content/plugins/elementor/assets/js/webpack.runtime.min.js?ver=3.31.2" id="elementor-webpack-runtime-js"></script>
-<script src="/wp-content/plugins/elementor/assets/js/frontend-modules.min.js?ver=3.31.2" id="elementor-frontend-modules-js"></script>
+<script src="/assets/js/webpack.runtime.min.js?ver=3.31.2" id="elementor-webpack-runtime-js"></script>
+<script src="/assets/js/frontend-modules.min.js?ver=3.31.2" id="elementor-frontend-modules-js"></script>
 <script src="/wp-includes/js/jquery/ui/core.min.js?ver=1.13.3" id="jquery-ui-core-js"></script>
 <script id="elementor-frontend-js-before">
 var elementorFrontendConfig = {"environmentMode":{"edit":false,"wpPreview":false,"isScriptDebug":false},"i18n":{"shareOnFacebook":"Share on Facebook","shareOnTwitter":"Share on Twitter","pinIt":"Pin it","download":"Download","downloadImage":"Download image","fullscreen":"Fullscreen","zoom":"Zoom","share":"Share","playVideo":"Play Video","previous":"Previous","next":"Next","close":"Close","a11yCarouselPrevSlideMessage":"Previous slide","a11yCarouselNextSlideMessage":"Next slide","a11yCarouselFirstSlideMessage":"This is the first slide","a11yCarouselLastSlideMessage":"This is the last slide","a11yCarouselPaginationBulletMessage":"Go to slide"},"is_rtl":false,"breakpoints":{"xs":0,"sm":480,"md":768,"lg":1025,"xl":1440,"xxl":1600},"responsive":{"breakpoints":{"mobile":{"label":"Mobile Portrait","value":767,"default_value":767,"direction":"max","is_enabled":true},"mobile_extra":{"label":"Mobile Landscape","value":880,"default_value":880,"direction":"max","is_enabled":false},"tablet":{"label":"Tablet Portrait","value":1024,"default_value":1024,"direction":"max","is_enabled":true},"tablet_extra":{"label":"Tablet Landscape","value":1200,"default_value":1200,"direction":"max","is_enabled":false},"laptop":{"label":"Laptop","value":1366,"default_value":1366,"direction":"max","is_enabled":false},"widescreen":{"label":"Widescreen","value":2400,"default_value":2400,"direction":"min","is_enabled":false}},"hasCustomBreakpoints":false},"version":"3.31.2","is_static":false,"experimentalFeatures":{"additional_custom_breakpoints":true,"container":true,"nested-elements":true,"e_element_cache":true,"home_screen":true,"global_classes_should_enforce_capabilities":true,"e_variables":true,"cloud-library":true,"e_opt_in_v4_page":true},"urls":{"assets":"\\/wp-content\/plugins\/elementor\/assets\/","ajaxurl":"\\/wp-admin\/admin-ajax.php","uploadUrl":"\\/wp-content\/uploads"},"nonces":{"floatingButtonsClickTracking":"26fd0e093b"},"swiperClass":"swiper","settings":{"page":[],"editorPreferences":[]},"kit":{"active_breakpoints":["viewport_mobile","viewport_tablet"],"global_image_lightbox":"yes","lightbox_enable_counter":"yes","lightbox_enable_fullscreen":"yes","lightbox_enable_zoom":"yes","lightbox_enable_share":"yes","lightbox_title_src":"title","lightbox_description_src":"description"},"post":{"id":682,"title":"Terms%20-%20DigitalCraft","excerpt":"","featuredImage":false}};
 </script>
-<script src="/wp-content/plugins/elementor/assets/js/frontend.min.js?ver=3.31.2" id="elementor-frontend-js"></script>
+<script src="/assets/js/frontend.min.js?ver=3.31.2" id="elementor-frontend-js"></script>
 			<script>
 			/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())},!1);
 			</script>

--- a/terms/index.html
+++ b/terms/index.html
@@ -62,18 +62,18 @@ window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/16
 :root :where(.wp-block-pullquote){font-size: 1.5em;line-height: 1.6;}
 </style>
 <link rel="stylesheet" id="hfe-style-css" href="/wp-content/plugins/header-footer-elementor/assets/css/header-footer-elementor.css?ver=2.4.9" media="all">
-<link rel="stylesheet" id="elementor-icons-css" href="/wp-content/plugins/elementor/assets/lib/eicons/css/elementor-icons.min.css?ver=5.43.0" media="all">
-<link rel="stylesheet" id="elementor-frontend-css" href="/wp-content/plugins/elementor/assets/css/frontend.min.css?ver=3.31.2" media="all">
+<link rel="stylesheet" id="elementor-icons-css" href="/assets/lib/eicons/css/elementor-icons.min.css?ver=5.43.0" media="all">
+<link rel="stylesheet" id="elementor-frontend-css" href="/assets/css/frontend.min.css?ver=3.31.2" media="all">
 <link rel="stylesheet" id="elementor-post-1439-css" href="/wp-content/uploads/elementor/css/post-1439.css?ver=1756072020" media="all">
-<link rel="stylesheet" id="widget-heading-css" href="/wp-content/plugins/elementor/assets/css/widget-heading.min.css?ver=3.31.2" media="all">
+<link rel="stylesheet" id="widget-heading-css" href="/assets/css/widget-heading.min.css?ver=3.31.2" media="all">
 <link rel="stylesheet" id="elementor-post-682-css" href="/wp-content/uploads/elementor/css/post-682.css?ver=1756072572" media="all">
 <link rel="stylesheet" id="uag-style-682-css" href="/wp-content/uploads/uag-plugin/assets/1000/uag-css-682.css?ver=1756065228" media="all">
-<link rel="stylesheet" id="hfe-elementor-icons-css" href="/wp-content/plugins/elementor/assets/lib/eicons/css/elementor-icons.min.css?ver=5.34.0" media="all">
-<link rel="stylesheet" id="hfe-icons-list-css" href="/wp-content/plugins/elementor/assets/css/widget-icon-list.min.css?ver=3.24.3" media="all">
-<link rel="stylesheet" id="hfe-social-icons-css" href="/wp-content/plugins/elementor/assets/css/widget-social-icons.min.css?ver=3.24.0" media="all">
-<link rel="stylesheet" id="hfe-social-share-icons-brands-css" href="/wp-content/plugins/elementor/assets/lib/font-awesome/css/brands.css?ver=5.15.3" media="all">
-<link rel="stylesheet" id="hfe-social-share-icons-fontawesome-css" href="/wp-content/plugins/elementor/assets/lib/font-awesome/css/fontawesome.css?ver=5.15.3" media="all">
-<link rel="stylesheet" id="hfe-nav-menu-icons-css" href="/wp-content/plugins/elementor/assets/lib/font-awesome/css/solid.css?ver=5.15.3" media="all">
+<link rel="stylesheet" id="hfe-elementor-icons-css" href="/assets/lib/eicons/css/elementor-icons.min.css?ver=5.34.0" media="all">
+<link rel="stylesheet" id="hfe-icons-list-css" href="/assets/css/widget-icon-list.min.css?ver=3.24.3" media="all">
+<link rel="stylesheet" id="hfe-social-icons-css" href="/assets/css/widget-social-icons.min.css?ver=3.24.0" media="all">
+<link rel="stylesheet" id="hfe-social-share-icons-brands-css" href="/assets/lib/font-awesome/css/brands.css?ver=5.15.3" media="all">
+<link rel="stylesheet" id="hfe-social-share-icons-fontawesome-css" href="/assets/lib/font-awesome/css/fontawesome.css?ver=5.15.3" media="all">
+<link rel="stylesheet" id="hfe-nav-menu-icons-css" href="/assets/lib/font-awesome/css/solid.css?ver=5.15.3" media="all">
 <!--link rel="stylesheet" id="elementor-gf-local-roboto-css" href="/wp-content/uploads/elementor/google-fonts/css/roboto.css?ver=1755546534" media="all"-->
 <!--link rel="stylesheet" id="elementor-gf-local-robotoslab-css" href="/wp-content/uploads/elementor/google-fonts/css/robotoslab.css?ver=1755546652" media="all"-->
 <!--[if IE]>
@@ -340,13 +340,13 @@ jQuery( document ).ready( function($) {
 var starter_templates_zip_preview = {"AstColorPaletteVarPrefix":"--ast-global-color-","AstEleColorPaletteVarPrefix":["ast-global-color-0","ast-global-color-1","ast-global-color-2","ast-global-color-3","ast-global-color-4","ast-global-color-5","ast-global-color-6","ast-global-color-7","ast-global-color-8"]};
 </script>
 <script src="/wp-content/plugins/astra-sites/inc/lib/onboarding/assets/dist/template-preview/main.js?ver=06758d4d807d9d22c6ea" id="starter-templates-zip-preview-js"></script>
-<script src="/wp-content/plugins/elementor/assets/js/webpack.runtime.min.js?ver=3.31.2" id="elementor-webpack-runtime-js"></script>
-<script src="/wp-content/plugins/elementor/assets/js/frontend-modules.min.js?ver=3.31.2" id="elementor-frontend-modules-js"></script>
+<script src="/assets/js/webpack.runtime.min.js?ver=3.31.2" id="elementor-webpack-runtime-js"></script>
+<script src="/assets/js/frontend-modules.min.js?ver=3.31.2" id="elementor-frontend-modules-js"></script>
 <script src="/wp-includes/js/jquery/ui/core.min.js?ver=1.13.3" id="jquery-ui-core-js"></script>
 <script id="elementor-frontend-js-before">
 var elementorFrontendConfig = {"environmentMode":{"edit":false,"wpPreview":false,"isScriptDebug":false},"i18n":{"shareOnFacebook":"Share on Facebook","shareOnTwitter":"Share on Twitter","pinIt":"Pin it","download":"Download","downloadImage":"Download image","fullscreen":"Fullscreen","zoom":"Zoom","share":"Share","playVideo":"Play Video","previous":"Previous","next":"Next","close":"Close","a11yCarouselPrevSlideMessage":"Previous slide","a11yCarouselNextSlideMessage":"Next slide","a11yCarouselFirstSlideMessage":"This is the first slide","a11yCarouselLastSlideMessage":"This is the last slide","a11yCarouselPaginationBulletMessage":"Go to slide"},"is_rtl":false,"breakpoints":{"xs":0,"sm":480,"md":768,"lg":1025,"xl":1440,"xxl":1600},"responsive":{"breakpoints":{"mobile":{"label":"Mobile Portrait","value":767,"default_value":767,"direction":"max","is_enabled":true},"mobile_extra":{"label":"Mobile Landscape","value":880,"default_value":880,"direction":"max","is_enabled":false},"tablet":{"label":"Tablet Portrait","value":1024,"default_value":1024,"direction":"max","is_enabled":true},"tablet_extra":{"label":"Tablet Landscape","value":1200,"default_value":1200,"direction":"max","is_enabled":false},"laptop":{"label":"Laptop","value":1366,"default_value":1366,"direction":"max","is_enabled":false},"widescreen":{"label":"Widescreen","value":2400,"default_value":2400,"direction":"min","is_enabled":false}},"hasCustomBreakpoints":false},"version":"3.31.2","is_static":false,"experimentalFeatures":{"additional_custom_breakpoints":true,"container":true,"nested-elements":true,"e_element_cache":true,"home_screen":true,"global_classes_should_enforce_capabilities":true,"e_variables":true,"cloud-library":true,"e_opt_in_v4_page":true},"urls":{"assets":"\\/wp-content\/plugins\/elementor\/assets\/","ajaxurl":"\\/wp-admin\/admin-ajax.php","uploadUrl":"\\/wp-content\/uploads"},"nonces":{"floatingButtonsClickTracking":"26fd0e093b"},"swiperClass":"swiper","settings":{"page":[],"editorPreferences":[]},"kit":{"active_breakpoints":["viewport_mobile","viewport_tablet"],"global_image_lightbox":"yes","lightbox_enable_counter":"yes","lightbox_enable_fullscreen":"yes","lightbox_enable_zoom":"yes","lightbox_enable_share":"yes","lightbox_title_src":"title","lightbox_description_src":"description"},"post":{"id":682,"title":"Terms%20-%20DigitalCraft","excerpt":"","featuredImage":false}};
 </script>
-<script src="/wp-content/plugins/elementor/assets/js/frontend.min.js?ver=3.31.2" id="elementor-frontend-js"></script>
+<script src="/assets/js/frontend.min.js?ver=3.31.2" id="elementor-frontend-js"></script>
 			<script>
 			/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())},!1);
 			</script>


### PR DESCRIPTION
## Summary
- simplify Elementor asset references from `/wp-content/plugins/elementor/assets/` to `/assets/` across site pages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2f86c2d48322925b2f8df6844885