### PR TITLE
Add Hebrew accessibility menu

### DIFF
--- a/assets/css/accessibility.css
+++ b/assets/css/accessibility.css
@@ -1,0 +1,74 @@
+#accessibility-toolbar {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  z-index: 10000;
+  direction: rtl;
+  font-family: sans-serif;
+}
+#accessibility-toolbar button {
+  margin: 2px;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+#acc-menu {
+  display: none;
+  background: #fff;
+  border: 1px solid #000;
+  padding: 10px;
+  margin-top: 5px;
+  text-align: right;
+}
+#acc-menu.show {
+  display: block;
+}
+#acc-menu .acc-section {
+  margin-bottom: 8px;
+}
+#acc-menu .acc-section span {
+  display: block;
+  margin-bottom: 4px;
+}
+#acc-menu .acc-font-btn {
+  font-size: 16px;
+}
+#acc-menu .acc-font-btn[data-size="2"] {
+  font-size: 18px;
+}
+#acc-menu .acc-font-btn[data-size="3"] {
+  font-size: 20px;
+}
+#acc-menu .acc-font-btn[data-size="4"] {
+  font-size: 22px;
+}
+
+body.fs-1 { font-size: 100%; }
+body.fs-2 { font-size: 110%; }
+body.fs-3 { font-size: 120%; }
+body.fs-4 { font-size: 130%; }
+
+body.dark-contrast {
+  background: #000 !important;
+  color: #fff !important;
+}
+body.dark-contrast a { color: #0ff !important; }
+
+body.light-contrast {
+  background: #fff !important;
+  color: #000 !important;
+}
+body.light-contrast a { color: #00f !important; }
+
+body.color-blind {
+  filter: grayscale(100%);
+}
+
+body.highlight-links a {
+  background: yellow !important;
+  text-decoration: underline !important;
+  color: #000 !important;
+}
+
+body.readable-font {
+  font-family: "Arial", sans-serif !important;
+}

--- a/assets/js/accessibility.js
+++ b/assets/js/accessibility.js
@@ -1,0 +1,93 @@
+(function() {
+  const cssLink = document.createElement('link');
+  cssLink.rel = 'stylesheet';
+  cssLink.href = '/assets/css/accessibility.css';
+  document.head.appendChild(cssLink);
+
+  function setFontSize(level) {
+    document.body.classList.remove('fs-1','fs-2','fs-3','fs-4');
+    document.body.classList.add('fs-' + level);
+    localStorage.setItem('acc-font-size', level);
+  }
+
+  function toggleSetting(cls) {
+    document.body.classList.toggle(cls);
+    localStorage.setItem('acc-' + cls, document.body.classList.contains(cls));
+  }
+
+  function applyStored() {
+    const size = localStorage.getItem('acc-font-size');
+    if (size) setFontSize(size);
+    ['dark-contrast','light-contrast','color-blind','highlight-links','readable-font'].forEach(cls => {
+      if (localStorage.getItem('acc-' + cls) === 'true') {
+        document.body.classList.add(cls);
+      }
+    });
+  }
+
+  function resetSettings() {
+    ['dark-contrast','light-contrast','color-blind','highlight-links','readable-font','fs-1','fs-2','fs-3','fs-4'].forEach(cls => {
+      document.body.classList.remove(cls);
+    });
+    ['acc-dark-contrast','acc-light-contrast','acc-color-blind','acc-highlight-links','acc-readable-font','acc-font-size'].forEach(k => localStorage.removeItem(k));
+  }
+
+  function buildMenu() {
+    const toolbar = document.createElement('div');
+    toolbar.id = 'accessibility-toolbar';
+    toolbar.innerHTML = `
+      <button id="acc-menu-toggle">תפריט נגישות</button>
+      <div id="acc-menu">
+        <div class="acc-section">
+          <span>גודל טקסט</span>
+          <button class="acc-font-btn" data-size="1">קטן</button>
+          <button class="acc-font-btn" data-size="2">רגיל</button>
+          <button class="acc-font-btn" data-size="3">גדול</button>
+          <button class="acc-font-btn" data-size="4">ענק</button>
+        </div>
+        <button id="acc-dark">ניגודיות כהה</button>
+        <button id="acc-light">ניגודיות בהירה</button>
+        <button id="acc-color-blind">התאמת צבעים לעיוורי צבעים</button>
+        <button id="acc-highlight">הדגשת קישורים</button>
+        <button id="acc-readable">פונט קריא</button>
+        <button id="acc-reset">איפוס הגדרות</button>
+      </div>
+    `;
+    document.body.appendChild(toolbar);
+
+    const menu = document.getElementById('acc-menu');
+    document.getElementById('acc-menu-toggle').addEventListener('click', () => {
+      menu.classList.toggle('show');
+    });
+
+    document.querySelectorAll('.acc-font-btn').forEach(btn => {
+      btn.addEventListener('click', () => setFontSize(btn.getAttribute('data-size')));
+    });
+
+    document.getElementById('acc-dark').addEventListener('click', () => {
+      document.body.classList.remove('light-contrast');
+      localStorage.removeItem('acc-light-contrast');
+      toggleSetting('dark-contrast');
+    });
+
+    document.getElementById('acc-light').addEventListener('click', () => {
+      document.body.classList.remove('dark-contrast');
+      localStorage.removeItem('acc-dark-contrast');
+      toggleSetting('light-contrast');
+    });
+
+    document.getElementById('acc-color-blind').addEventListener('click', () => toggleSetting('color-blind'));
+    document.getElementById('acc-highlight').addEventListener('click', () => toggleSetting('highlight-links'));
+    document.getElementById('acc-readable').addEventListener('click', () => toggleSetting('readable-font'));
+    document.getElementById('acc-reset').addEventListener('click', () => {
+      resetSettings();
+      menu.classList.remove('show');
+    });
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    applyStored();
+    buildMenu();
+  });
+})();
+

--- a/index.html
+++ b/index.html
@@ -859,5 +859,6 @@ var elementorFrontendConfig = {"environmentMode":{"edit":false,"wpPreview":false
 			<script>
 			/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())},!1);
 			</script>
-				</body>
+				  <script src="/assets/js/accessibility.js" defer></script>
+  </body>
 </html><!-- Page supported by LiteSpeed Cache 7.3.0.1 on 2025-08-25 02:38:53 -->

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -381,5 +381,6 @@ var elementorFrontendConfig = {"environmentMode":{"edit":false,"wpPreview":false
 			<script>
 			/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())},!1);
 			</script>
-				</body>
+				  <script src="/assets/js/accessibility.js" defer></script>
+  </body>
 </html><!-- Page supported by LiteSpeed Cache 7.3.0.1 on 2025-08-25 02:17:39 -->

--- a/terms/index.html
+++ b/terms/index.html
@@ -350,5 +350,6 @@ var elementorFrontendConfig = {"environmentMode":{"edit":false,"wpPreview":false
 			<script>
 			/(trident|msie)/i.test(navigator.userAgent)&&document.getElementById&&window.addEventListener&&window.addEventListener("hashchange",function(){var t,e=location.hash.substring(1);/^[A-z0-9_-]+$/.test(e)&&(t=document.getElementById(e))&&(/^(?:a|select|input|button|textarea)$/i.test(t.tagName)||(t.tabIndex=-1),t.focus())},!1);
 			</script>
-				</body>
+				  <script src="/assets/js/accessibility.js" defer></script>
+  </body>
 </html><!-- Page supported by LiteSpeed Cache 7.3.0.1 on 2025-08-25 04:01:41 -->


### PR DESCRIPTION
## Summary
- add Hebrew accessibility toolbar with font size, contrast, color-blind, link highlight, readable font and reset options
- style accessibility controls and body classes
- load accessibility script on all static pages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae352679ec8322a2cd8e528e803810