### PR TITLE
Use icon for accessibility menu toggle

### DIFF
--- a/assets/css/accessibility.css
+++ b/assets/css/accessibility.css
@@ -11,6 +11,9 @@
   padding: 6px 8px;
   cursor: pointer;
 }
+#acc-menu-toggle {
+  font-size: 24px;
+}
 #acc-menu {
   display: none;
   background: #fff;

--- a/assets/js/accessibility.js
+++ b/assets/js/accessibility.js
@@ -36,7 +36,7 @@
     const toolbar = document.createElement('div');
     toolbar.id = 'accessibility-toolbar';
     toolbar.innerHTML = `
-      <button id="acc-menu-toggle">תפריט נגישות</button>
+      <button id="acc-menu-toggle" aria-label="תפריט נגישות"><span class="acc-icon" aria-hidden="true">&#x267F;</span></button>
       <div id="acc-menu">
         <div class="acc-section">
           <span>גודל טקסט</span>


### PR DESCRIPTION
## Summary
- replace text-based accessibility menu toggle with a wheelchair icon and aria-label
- style the toggle to display icon at larger size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae38fb77748322abc8ceb168dd5222