### PR TITLE
Center Privacy Policy page layout

### DIFF
--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -114,7 +114,7 @@ flexibility(document.documentElement);
 			</style>
 			</head>
 
-<body itemtype="https://schema.org/WebPage" itemscope="itemscope" class="privacy-policy wp-singular page-template-default page page-id-1544 wp-custom-logo wp-theme-astra eio-default edd-js-none ehf-template-astra ehf-stylesheet-astra ally-default ast-desktop ast-separate-container ast-right-sidebar astra-4.11.9 ast-single-post ast-inherit-site-logo-transparent ast-hfb-header ast-normal-title-enabled elementor-default elementor-kit-1439 elementor-page elementor-page-1544">
+<body itemtype="https://schema.org/WebPage" itemscope="itemscope" class="privacy-policy wp-singular page-template-default page page-id-1544 wp-custom-logo wp-theme-astra eio-default edd-js-none ehf-template-astra ehf-stylesheet-astra ally-default ast-desktop ast-page-builder-template ast-no-sidebar astra-4.11.9 ast-single-post ast-inherit-site-logo-transparent ast-theme-transparent-header ast-hfb-header elementor-default elementor-kit-1439 elementor-page elementor-page-1544">
 	<style>.edd-js-none .edd-has-js, .edd-js .edd-no-js, body.edd-js input.edd-no-js { display: none; }</style>
 	<script>/* <![CDATA[ */(function(){var c = document.body.classList;c.remove('edd-js-none');c.add('edd-js');})();/* ]]> */</script>
 	


### PR DESCRIPTION
## Summary
- Centered the Privacy Policy page by switching layout to no-sidebar and page-builder template.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4dfe509c8322b3293dffdf0b90af