### PR TITLE
Align privacy policy layout with terms design

### DIFF
--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -181,16 +181,22 @@ flexibility(document.documentElement);
 					<main id="main" class="site-main">
 				<article class="post-1544 page type-page status-publish ast-article-single" id="post-1544" itemtype="https://schema.org/CreativeWork" itemscope="itemscope">
 	
-				<header class="entry-header ast-header-without-markup">
-				<h1 class="entry-title" itemprop="headline">Privacy &amp; Policy</h1>			</header> <!-- .entry-header -->
+				<header class="entry-header ast-no-title ast-header-without-markup">
+                                </header> <!-- .entry-header -->
 		
 <div class="entry-content clear" itemprop="text">
 
 	
 			<div data-elementor-type="wp-page" data-elementor-id="1544" class="elementor elementor-1544">
-				<div class="elementor-element elementor-element-31e13f8d e-flex e-con-boxed e-con e-parent" data-id="31e13f8d" data-element_type="container">
-					<div class="e-con-inner">
-				                                <div class="elementor-element elementor-element-2e66f3ad elementor-widget elementor-widget-text-editor" data-id="2e66f3ad" data-element_type="widget" data-widget_type="text-editor.default">
+                                <div class="elementor-element elementor-element-a307bd8 e-flex e-con-boxed e-con e-parent" data-id="a307bd8" data-element_type="container" data-settings='{"background_background":"classic"}'>
+                                        <div class="e-con-inner">
+                <div class="elementor-element elementor-element-3c7ee35 e-con-full e-flex e-con e-child" data-id="3c7ee35" data-element_type="container">
+                                <div class="elementor-element elementor-element-6b5461e elementor-widget elementor-widget-heading" data-id="6b5461e" data-element_type="widget" data-widget_type="heading.default">
+                                <div class="elementor-widget-container">
+                                        <h2 class="elementor-heading-title elementor-size-default"><strong>Privacy &amp; Policy</strong></h2>
+                                </div>
+                                </div>
+                                <div class="elementor-element elementor-element-2e66f3ad elementor-widget elementor-widget-text-editor" data-id="2e66f3ad" data-element_type="widget" data-widget_type="text-editor.default">
                                 <div class="elementor-widget-container">
                                     <h3>1. Information We Collect</h3>
                                     <ul>
@@ -219,9 +225,10 @@ flexibility(document.documentElement);
                                     <p>If you have any questions about this Privacy Policy, please contact us at: <a href="mailto:support@digitalcraft.dev">support@digitalcraft.dev</a></p>
                                 </div>
                                 </div>
-					</div>
-				</div>
-				</div>
+                </div>
+                                        </div>
+                                </div>
+                                </div>
 		
 	
 	


### PR DESCRIPTION
## Summary
- Match privacy policy page layout and widgets to the terms page design while preserving content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae4feb413c8322860311c4fd329cf1